### PR TITLE
Hotfix: fix premature loop exit by relocating drain logic

### DIFF
--- a/charge_point.go
+++ b/charge_point.go
@@ -537,18 +537,19 @@ func (cp *ChargePoint) callDispatcher() {
 			goto CleanupDrain
 		}
 
-	CleanupDrain:
-		log.Debug("charge point is closed, draining queue")
-		for {
-			select {
-			case ch, ok := <-cp.dispatcherIn:
-				if !ok {
-					return
-				}
-				close(ch.recvChan)
-			default:
+	}
+
+CleanupDrain:
+	log.Debug("charge point is closed, draining queue")
+	for {
+		select {
+		case ch, ok := <-cp.dispatcherIn:
+			if !ok {
 				return
 			}
+			close(ch.recvChan)
+		default:
+			return
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR fixes a critical bug introduced in a previous commit where `callDispatcher` would exit prematurely after processing the first request.

## Key Changes

- **Moved `CleanupDrain` block**: The cleanup and channel draining logic has been moved outside the main `for` loop.
- **Fixed Control Flow**: Previously, the execution flow unintentionally fell through to the `CleanupDrain` label after a successful `select` case. Now, the cleanup logic is only reachable via a specific `goto` statement upon receiving a stop signal.

## Related Issue

#9


I worked on the master branch, so I made a pr again