### PR TITLE
[Bug]: Update v16 package to align with OCPP 1.6 JSON spec

### DIFF
--- a/v16/call.go
+++ b/v16/call.go
@@ -34,7 +34,7 @@ type HeartbeatReq struct{}
 
 type MeterValuesReq struct {
 	ConnectorId   *int         `json:"connectorId" validate:"required,gte=0"`
-	TransactionId int         `json:"transactionId"`
+	TransactionId int          `json:"transactionId"`
 	MeterValue    []MeterValue `json:"meterValue" validate:"required,gt=0,dive"`
 }
 
@@ -59,7 +59,7 @@ type StatusNotificationReq struct {
 // temporary type for unmarshalling
 type StopTransactionReq struct {
 	IdTag           string       `json:"idTag" validate:"omitempty,max=20"`
-	MeterStop       *int          `json:"meterStop" validate:"required"`
+	MeterStop       *int         `json:"meterStop" validate:"required"`
 	Timestamp       string       `json:"timestamp" validate:"required,ISO8601date"`
 	TransactionId   int          `json:"transactionId" validate:"required"`
 	Reason          string       `json:"reason,omitempty" validate:"omitempty,Reason"`
@@ -79,13 +79,13 @@ type ChangeAvailabilityReq struct {
 
 type ChangeConfigurationReq struct {
 	Key   string `json:"key" validate:"required,max=50"`
-	Value string `json:"value" validate:"required,max=50"`
+	Value string `json:"value" validate:"required,max=500"`
 }
 
 type ClearCacheReq struct{}
 
 type ClearChargingProfileReq struct {
-	Id                     string `json:"id,omitempty"`
+	Id                     *int   `json:"id,omitempty"`
 	ConnectorId            *int   `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
 	ChargingProfilePurpose string `json:"chargingProfilePurpose,omitempty" validate:"omitempty,ChargingProfilePurpose"`
 	StackLevel             *int   `json:"stackLevel,omitempty" validate:"omitempty,gte=0"`
@@ -93,7 +93,7 @@ type ClearChargingProfileReq struct {
 
 type GetCompositeScheduleReq struct {
 	ConnectorId      *int   `json:"connectorId,omitempty" validate:"omitempty,gte=0"`
-	Duration         int   `json:"duration" validate:"required,gt=0"`
+	Duration         int    `json:"duration" validate:"required,gt=0"`
 	ChargingRateUnit string `json:"chargingRateUnit,omitempty" validate:"omitempty,ChargingRateUnit"`
 }
 
@@ -103,8 +103,8 @@ type GetConfigurationReq struct {
 
 type GetDiagnosticsReq struct {
 	Location      string `json:"location" validate:"required"`
-	Retries       int   `json:"retries,omitempty" validate:"omitempty,gt=0"`
-	RetryInterval int   `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
+	Retries       int    `json:"retries,omitempty" validate:"omitempty,gt=0"`
+	RetryInterval int    `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
 	StartTime     string `json:"startTime,omitempty" validate:"omitempty,ISO8601date"`
 	StopTime      string `json:"stopTime,omitempty" validate:"omitempty,ISO8601date"`
 }
@@ -155,9 +155,9 @@ type UnlockConnectorReq struct {
 
 type UpdateFirmwareReq struct {
 	Location      string `json:"location" validate:"required"`
-	Retries       int   `json:"retries,omitempty" validate:"omitempty,gt=0"`
+	Retries       int    `json:"retries,omitempty" validate:"omitempty,gt=0"`
 	RetrieveDate  string `json:"retrieveDate" validate:"required,ISO8601date"`
-	RetryInterval int   `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
+	RetryInterval int    `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
 }
 
 // OCPP 1.6 security whitepaper edition 2 implementation
@@ -172,7 +172,7 @@ type DeleteCertificateReq struct {
 
 type ExtendedTriggerMessageReq struct {
 	RequestedMessage string `json:"requestedMessage" validate:"required,MessageTriggerEnumType"`
-	ConnectorId      *int    `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
+	ConnectorId      *int   `json:"connectorId,omitempty" validate:"omitempty,gt=0"`
 }
 
 type GetInstalledCertificateIdsReq struct {
@@ -180,11 +180,11 @@ type GetInstalledCertificateIdsReq struct {
 }
 
 type GetLogReq struct {
-	LogType       string `json:"logType" validate:"required,LogEnumType"`
-	RequestId     int    `json:"requestId" validate:"required"`
-	Retries       int   `json:"retries,omitempty" validate:"omitempty,gt=0"`
-	RetryInterval int   `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
-	Log           string `json:"log" validate:"required,LogParametersType"`
+	LogType       string            `json:"logType" validate:"required,LogEnumType"`
+	RequestId     int               `json:"requestId" validate:"required"`
+	Retries       int               `json:"retries,omitempty" validate:"omitempty,gt=0"`
+	RetryInterval int               `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
+	Log           LogParametersType `json:"log" validate:"required,LogParametersType"`
 }
 
 type InstallCertificateReq struct {
@@ -204,8 +204,7 @@ type SecurityEventNotificationReq struct {
 }
 
 type SignCertificateReq struct {
-	Csr    string `json:"csr" validate:"required,max=5500"`
-	Status string `json:"status" validate:"required,CertificateStatusEnumType"`
+	Csr string `json:"csr" validate:"required,max=5500"`
 }
 
 type SignedFirmwareStatusNotificationReq struct {
@@ -214,8 +213,8 @@ type SignedFirmwareStatusNotificationReq struct {
 }
 
 type SignedUpdateFirmwareReq struct {
-	Retries       int   `json:"retries,omitempty" validate:"omitempty,gt=0"`
-	RetryInterval int   `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
+	Retries       int    `json:"retries,omitempty" validate:"omitempty,gt=0"`
+	RetryInterval int    `json:"retryInterval,omitempty" validate:"omitempty,gt=0"`
 	RequestId     int    `json:"requestId" validate:"required"`
 	Firmware      string `json:"firmware" validate:"required,FirewareType"`
 }

--- a/v16/call_result.go
+++ b/v16/call_result.go
@@ -6,13 +6,13 @@ type AuthorizeConf struct {
 
 type BootNotificationConf struct {
 	CurrentTime string `json:"currentTime" validate:"required,ISO8601date"`
-	Interval    int   `json:"interval" validate:"required,gte=0"`
+	Interval    int    `json:"interval" validate:"required,gte=0"`
 	Status      string `json:"status" validate:"required,RegistrationStatus"`
 }
 
 type DataTransferConf struct {
 	Status string `json:"status" validate:"required,DataTransferStatus"`
-	Data   string `json:"data,omitempty"`
+	Data   any    `json:"data,omitempty"`
 }
 
 type DiagnosticsStatusNotificationConf struct{}
@@ -33,7 +33,7 @@ type StartTransactionConf struct {
 type StatusNotificationConf struct{}
 
 type StopTransactionConf struct {
-	IdTagInfo IdTagInfo `json:"idTagInfo" validate:"required"`
+	IdTagInfo *IdTagInfo `json:"idTagInfo" validate:"omitempty"`
 }
 
 type CancelReservationConf struct {
@@ -57,15 +57,15 @@ type ClearChargingProfileConf struct {
 }
 
 type GetCompositeScheduleConf struct {
-	Status           string           `json:"status" validate:"required,GetCompositeScheduleStatus"`
-	ConnectorId      int              `json:"connectorId" validate:"required,gte=0"`
-	ScheduleStart    string           `json:"scheduleStart,omitempty" validate:"omitempty,ISO8601date"`
+	Status           string            `json:"status" validate:"required,GetCompositeScheduleStatus"`
+	ConnectorId      *int              `json:"connectorId" validate:"omitempty,gte=0"`
+	ScheduleStart    string            `json:"scheduleStart,omitempty" validate:"omitempty,ISO8601date"`
 	ChargingSchedule *ChargingSchedule `json:"chargingSchedule,omitempty"`
 }
 
 type GetConfigurationConf struct {
-	ConfigurationKey map[string]string `json:"configurationKey,omitempty"`
-	UnknownKey       []string          `json:"unknownKey,omitempty" validate:"omitempty,max=50"`
+	ConfigurationKey []KeyValue `json:"configurationKey,omitempty"`
+	UnknownKey       []string   `json:"unknownKey,omitempty" validate:"omitempty,dive,max=50"`
 }
 
 type GetDiagnosticsConf struct {

--- a/v16/datatypes.go
+++ b/v16/datatypes.go
@@ -43,7 +43,7 @@ type ChargingSchedule struct {
 }
 
 type ChargingSchedulePeriod struct {
-	StartPeriod  string  `json:"startPeriod" validate:"required,ISO8601date"`
+	StartPeriod  *int    `json:"startPeriod" validate:"required"`
 	Limit        float32 `json:"limit" validate:"required,gte=0"`
 	NumberPhases int     `json:"numberPhases,omitempty"`
 }
@@ -64,8 +64,8 @@ type CertificateHashDataType struct {
 
 type FirmwareType struct {
 	Location           string `json:"location" validate:"required,max=512"`
-	RetrieveDateTime   string `json:"retrieveDate" validate:"required,ISO8601date"`
-	InstallDateTime    string `json:"installDate,omitempty" validate:"omitempty,ISO8601date"`
+	RetrieveDateTime   string `json:"retrieveDateTime" validate:"required,ISO8601date"`
+	InstallDateTime    string `json:"installDateTime,omitempty" validate:"omitempty,ISO8601date"`
 	SigningCertificate string `json:"signingCertificate" validate:"required,max=5500"`
 	Signature          string `json:"signature" validate:"required,max=800"`
 }
@@ -74,4 +74,10 @@ type LogParametersType struct {
 	RemoteLocation  string `json:"remoteLocation" validate:"required,max=512"`
 	OldestTimestamp string `json:"oldestTimestamp,omitempty" validate:"omitempty,ISO8601date"`
 	LatestTimestamp string `json:"latestTimestamp,omitempty" validate:"omitempty,ISO8601date"`
+}
+
+type KeyValue struct {
+	Key      string `json:"key" validate:"required,max=50"`
+	Readonly bool   `json:"readonly" validate:"required"`
+	Value    string `json:"value,omitempty" validate:"omitempty,max=500"`
 }

--- a/v16/datatypes.go
+++ b/v16/datatypes.go
@@ -43,9 +43,9 @@ type ChargingSchedule struct {
 }
 
 type ChargingSchedulePeriod struct {
-	StartPeriod  *int    `json:"startPeriod" validate:"required"`
-	Limit        float32 `json:"limit" validate:"required,gte=0"`
-	NumberPhases int     `json:"numberPhases,omitempty"`
+	StartPeriod  *int     `json:"startPeriod" validate:"required"`
+	Limit        *float32 `json:"limit" validate:"required,gte=0"`
+	NumberPhases int      `json:"numberPhases,omitempty"`
 }
 
 type AuthorizationData struct {


### PR DESCRIPTION
## Description

This PR updates the structs in the `v16` package to strictly adhere to the OCPP 1.6 JSON specification.

## Key Changes
1. **datatypes.go**: Updated shared types to match the spec definitions.
2. **call.go (Requests)**: 
   - Fixed incorrect field types (e.g., `string` -> `int` for IDs).
   - Adjusted validation tags (e.g., `max` length).
3. **call_result.go (Confirmations)**:
   - Corrected structure for complex types (e.g., `GetConfigurationConf`).

## Related Issue

#13 